### PR TITLE
FX: Add default type to avoid bug in ComboBox

### DIFF
--- a/src/application/LoginController.java
+++ b/src/application/LoginController.java
@@ -243,6 +243,7 @@ public class LoginController extends Controller implements Initializable {
 		// TODO Auto-generated method stub
 		status = LoginView.Login;
 		typeCombo.getItems().setAll("Member", "Deliver", "Restaurant"); // set the options
+		typeCombo.setValue("Member");
 		render();
 	}
 }


### PR DESCRIPTION
Just add a default value, then type combo box will always not null.
Solve issue #9 